### PR TITLE
Added a (first version) ocr fullscreen button.

### DIFF
--- a/app/assets/javascripts/DkBreve.js
+++ b/app/assets/javascripts/DkBreve.js
@@ -108,3 +108,38 @@ $(document).on('kbosdready', function(e) {
     dkBreve.onKbOSDReady(e.detail.kbosd);
 });
 
+$(document).ready(function () {
+    // set up handler for ocr fullscreen
+    $('#ocrFullscreenButton').click(function(e) {
+        // Copy/Pasted from http://stackoverflow.com/questions/7130397/how-do-i-make-a-div-full-screen /HAFE
+        // if already full screen; exit
+        // else go fullscreen
+        if (
+            document.fullscreenElement ||
+            document.webkitFullscreenElement ||
+            document.mozFullScreenElement ||
+            document.msFullscreenElement
+        ) {
+            if (document.exitFullscreen) {
+                document.exitFullscreen();
+            } else if (document.mozCancelFullScreen) {
+                document.mozCancelFullScreen();
+            } else if (document.webkitExitFullscreen) {
+                document.webkitExitFullscreen();
+            } else if (document.msExitFullscreen) {
+                document.msExitFullscreen();
+            }
+        } else {
+            element = $('.ocr').get(0);
+            if (element.requestFullscreen) {
+                element.requestFullscreen();
+            } else if (element.mozRequestFullScreen) {
+                element.mozRequestFullScreen();
+            } else if (element.webkitRequestFullscreen) {
+                element.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+            } else if (element.msRequestFullscreen) {
+                element.msRequestFullscreen();
+            }
+        }
+    });
+});

--- a/app/assets/javascripts/DkBreve.js
+++ b/app/assets/javascripts/DkBreve.js
@@ -98,6 +98,17 @@ window.dkBreve = (function (window, $, undefined) {
 
                 $('.ocr').scroll(this.onOcrScroll);
             }
+        },
+        closeFullScreen : function () {
+            if (document.exitFullscreen) {
+                document.exitFullscreen();
+            } else if (document.mozCancelFullScreen) {
+                document.mozCancelFullScreen();
+            } else if (document.webkitExitFullscreen) {
+                document.webkitExitFullscreen();
+            } else if (document.msExitFullscreen) {
+                document.msExitFullscreen();
+            }
         }
     };
 
@@ -142,4 +153,6 @@ $(document).ready(function () {
             }
         }
     });
+
+    $('.escFullScreenButton').click(dkBreve.closeFullScreen);
 });

--- a/app/assets/stylesheets/dkbreve/letter.css.scss
+++ b/app/assets/stylesheets/dkbreve/letter.css.scss
@@ -92,7 +92,7 @@ h1[itemprop=name]{
   }
   &:-webkit-full-screen{
     padding:0 10%;
-    max-width:800px;
+    max-width:57em;
     background-color:#fff;
     .escFullScreenButton{
       display:block;
@@ -100,7 +100,7 @@ h1[itemprop=name]{
   }
   &:-moz-full-screen{
     padding:0 10%;
-    max-width:800px;
+    max-width:57em;
     background-color:#fff;
     .escFullScreenButton{
       display:block;
@@ -108,7 +108,7 @@ h1[itemprop=name]{
   }
   &:-ms-fullscreen{
     padding:0 10%;
-    max-width:800px;
+    max-width:57em;
     background-color:#fff;
     .escFullScreenButton{
       display:block;
@@ -116,7 +116,7 @@ h1[itemprop=name]{
   }
   &:fullscreen{
     padding:20px 10%;
-    max-width:800px;
+    max-width:57em;
     background-color:#fff;
     .escFullScreenButton{
       display:block;

--- a/app/assets/stylesheets/dkbreve/letter.css.scss
+++ b/app/assets/stylesheets/dkbreve/letter.css.scss
@@ -83,6 +83,32 @@ h1[itemprop=name]{
   position:absolute;
   bottom:0px;
   top:$letter-landingpage-header-height;
+  .escFullScreenButton{
+    display:none;
+    position:fixed;
+    top:30px;
+    right:30px;
+    opacity:0.8;
+  }
+  &:-webkit-full-screen{
+    padding:0 10%;
+    max-width:800px;
+    .escFullScreenButton{
+      display:block;
+    }
+  }
+  &:-moz-full-screen{
+    padding:0 10%;
+    max-width:800px;
+  }
+  &:-ms-fullscreen{
+    padding:0 10%;
+    max-width:800px;
+  }
+  &:fullscreen{
+    padding:20px 10%;
+    max-width:800px;
+  }
 }
 
 .kbFastNav input{

--- a/app/assets/stylesheets/dkbreve/letter.css.scss
+++ b/app/assets/stylesheets/dkbreve/letter.css.scss
@@ -94,6 +94,7 @@ h1[itemprop=name]{
     padding:0 10%;
     max-width:57em;
     background-color:#fff;
+    font-family:Serif;
     .escFullScreenButton{
       display:block;
     }
@@ -102,6 +103,7 @@ h1[itemprop=name]{
     padding:0 10%;
     max-width:57em;
     background-color:#fff;
+    font-family:Serif;
     .escFullScreenButton{
       display:block;
     }
@@ -110,6 +112,7 @@ h1[itemprop=name]{
     padding:0 10%;
     max-width:57em;
     background-color:#fff;
+    font-family:Serif;
     .escFullScreenButton{
       display:block;
     }
@@ -118,6 +121,7 @@ h1[itemprop=name]{
     padding:20px 10%;
     max-width:57em;
     background-color:#fff;
+    font-family:Serif;
     .escFullScreenButton{
       display:block;
     }

--- a/app/assets/stylesheets/dkbreve/letter.css.scss
+++ b/app/assets/stylesheets/dkbreve/letter.css.scss
@@ -93,6 +93,7 @@ h1[itemprop=name]{
   &:-webkit-full-screen{
     padding:0 10%;
     max-width:800px;
+    background-color:#fff;
     .escFullScreenButton{
       display:block;
     }
@@ -100,6 +101,7 @@ h1[itemprop=name]{
   &:-moz-full-screen{
     padding:0 10%;
     max-width:800px;
+    background-color:#fff;
     .escFullScreenButton{
       display:block;
     }
@@ -107,6 +109,7 @@ h1[itemprop=name]{
   &:-ms-fullscreen{
     padding:0 10%;
     max-width:800px;
+    background-color:#fff;
     .escFullScreenButton{
       display:block;
     }
@@ -114,6 +117,7 @@ h1[itemprop=name]{
   &:fullscreen{
     padding:20px 10%;
     max-width:800px;
+    background-color:#fff;
     .escFullScreenButton{
       display:block;
     }

--- a/app/assets/stylesheets/dkbreve/letter.css.scss
+++ b/app/assets/stylesheets/dkbreve/letter.css.scss
@@ -71,6 +71,12 @@ h1[itemprop=name]{
   position: absolute;
   top: 0px;
   bottom: 0px;
+  #ocrFullscreenButton{
+    border:0;
+    margin-top:1px; // FIXME: This is crap, I don't know why it doesn't act like the other buttons, but it don't. I have no more time for this unfortunately (AKA: Congratulations with your new job next frontender! ;-) )
+    padding-bottom:5px;
+    outline:none;
+  }
 }
 .ocr{
   overflow-y: auto;

--- a/app/assets/stylesheets/dkbreve/letter.css.scss
+++ b/app/assets/stylesheets/dkbreve/letter.css.scss
@@ -100,14 +100,23 @@ h1[itemprop=name]{
   &:-moz-full-screen{
     padding:0 10%;
     max-width:800px;
+    .escFullScreenButton{
+      display:block;
+    }
   }
   &:-ms-fullscreen{
     padding:0 10%;
     max-width:800px;
+    .escFullScreenButton{
+      display:block;
+    }
   }
   &:fullscreen{
     padding:20px 10%;
     max-width:800px;
+    .escFullScreenButton{
+      display:block;
+    }
   }
 }
 

--- a/app/views/catalog/_show_letter.html.erb
+++ b/app/views/catalog/_show_letter.html.erb
@@ -36,13 +36,14 @@
       <div class="container textAndFacsimileContainer">
         <div class="row">
           <div class="ocrContainer">
-            <button id="ocrFullscreenButton" class="btn btn-default pull-right"><span class="glyphicon glyphicon-fullscreen"></span></button>
+            <button id="ocrFullscreenButton" class="btn btn-default pull-right" title="Se tekst i fuld skærm"><span class="glyphicon glyphicon-fullscreen"></span></button>
             <div class="downloadLinkContainer">
               <%= link_to(solr_document_path(document, format: :pdf), class: 'btn btn-default dlButton') do %>
                   <span class="glyphicon glyphicon-save"></span> Tekst
               <% end %>
             </div>
             <article class="ocr">
+              <button class="escFullScreenButton btn btn-default" title="Tilbage til normal visning"><span class="glyphicon glyphicon-remove"></span></button>
               <%= Snippet::SnippetServer.render_snippet(opts) %>
             </article>
           </div>

--- a/app/views/catalog/_show_letter.html.erb
+++ b/app/views/catalog/_show_letter.html.erb
@@ -36,6 +36,7 @@
       <div class="container textAndFacsimileContainer">
         <div class="row">
           <div class="ocrContainer">
+            <button id="ocrFullscreenButton" class="btn btn-default pull-right"><span class="glyphicon glyphicon-fullscreen"></span></button>
             <div class="downloadLinkContainer">
               <%= link_to(solr_document_path(document, format: :pdf), class: 'btn btn-default dlButton') do %>
                   <span class="glyphicon glyphicon-save"></span> Tekst


### PR DESCRIPTION
@naderak @siglun @davidgrove73 

This isn't finished at all, but the functionallity works, and I think we should consider using it anyway, since it might help the users, even in this unfinished state?

There is a button that opens the ocr in a fullscreen view. There is (kind of) no back button, but (most?) browsers offers to go back by pressing escape.

The ocr just opens as is, and isn't (necessarily) scrolled in the neighbourhood of what was visible in the non fullscreen view.

And finally we should try to make it look more like the kbOSD fullscreen button (like hovering over the ocr pane in the bottom, and perhaps even use the same icon (that we for some obscure reason chose to include as a sprited png in the kbOSD project (I should be able to work even without bootstrap, as I recall it?)

But still: it do offer the users a chance to view the entire ocr in a fullscreen mode (we might also work on the margins and stuff like that).